### PR TITLE
Added `%simpletags_tag-raw%` placeholder

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -161,9 +161,9 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>com.github.Tweetzy</groupId>
-            <artifactId>Skulls</artifactId>
-            <version>3.23.0</version>
+            <groupId>ca.tweetzy</groupId>
+            <artifactId>skulls</artifactId>
+            <version>v3.23.0</version>
             <scope>provided</scope>
             <exclusions>
                 <exclusion>

--- a/src/main/java/me/refracdevelopment/simpletags/utilities/chat/PAPIExpansion.java
+++ b/src/main/java/me/refracdevelopment/simpletags/utilities/chat/PAPIExpansion.java
@@ -45,6 +45,16 @@ public class PAPIExpansion extends PlaceholderExpansion {
                 }
 
                 return RyMessageUtils.translate(profile.getTagPrefix());
+            case "tag-raw":
+                if (profile == null) {
+                    return "";
+                }
+
+                if (profile.getTagPrefix().isEmpty()) {
+                    return "";
+                }
+
+                return profile.getTagPrefix();
             case "tag-name":
             case "identifier":
                 if (profile == null) {


### PR DESCRIPTION
**Changes:**
- Added %simpletags_tag-raw% placeholder, this allows chat plugins to handle parsing themselves as some are incompatible with legacy spigot colours
- Updated a dependency as it is no longer accurate